### PR TITLE
13368

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ the odd code path, even if the point of the change wasn’t to fix the bug.
 
 [Rust]: https://github.com/rust-lang/rust
 
-As such, this repository is a collection of these bugs, and it runs once a
-day, on Travis. If any of the ICEs stop happening, the build will fail, and
-I can close the associated bug.
+As such, this repository is a collection of these bugs, and it runs on Rust
+nightly, once a day, on Travis. If any of the ICEs stop happening, the build
+will fail, and I can close the associated bug.
 
 ## Helping out
 

--- a/src/13368.rs
+++ b/src/13368.rs
@@ -1,0 +1,7 @@
+#![feature(asm)]
+
+fn main() {
+    let arr: [u8; 16];
+    unsafe { asm!("" : "=m"(arr)); }
+    println!("{:?}", arr);
+}

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,10 @@
+#!/bin/bash
+
 for f in src/*
 do
-        echo "Testing $f:"
-        rustc $f 2>&1 | grep "internal compiler error" || exit 1
+  echo "Testing $f:"
+  # Compile the code, and if it passes exit with error code
+  if rustc "$f" > /dev/null 2>&1; then
+    exit 1
+  fi
 done


### PR DESCRIPTION
- [x] Adds 'Array as asm output ICEs LLVM' ICE
- [x] Updates the test script to handle errors without matching message
If the rustc compiler passes, it should be considered an error and
reported.
- [x] Adds information about nightly run

Would you like those commits to be on separate PRs?