### PR TITLE
Adds 'rustc fails to detect duplicate switch cases due to integer overrflow' ICE

### DIFF
--- a/src/13727.rs
+++ b/src/13727.rs
@@ -1,0 +1,11 @@
+fn test(val: u8) {
+    match val {
+        256 => print!("0b1110\n"),
+        512 => print!("0b1111\n"),
+        _   => print!("fail\n"),
+    }
+}
+
+fn main() {
+    test(1);
+}


### PR DESCRIPTION
Reference: rust-lang/rust#13727