### PR TITLE
Adds "ICE with `rustc --version | false`" ICE

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+set -o pipefail
+echo "Testing 14505"
+if rustc --version 2>&1 | true; then
+  exit 1
+fi
+
 for f in src/*
 do
   echo "Testing $f:"


### PR DESCRIPTION
Reference: rust-lang/rust#14505

I was unsure if it would be better to write the Rust code on the comments, but covering `rustc --version` case seems to be a broader acceptance, as includes the compiler command itself to be fixed.