### PR TITLE
16229

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: rust
 rust: nightly
 script: bash test.sh
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y debootstrap

--- a/16229.sh
+++ b/16229.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [ "$(uname)" != Linux ]; then
+  echo "Only works on Linux"
+  exit 1
+fi
+
+if ! which debootstrap; then
+  echo "Requires debootstrap"
+  exit 1
+fi
+
+jail="/tmp/16229"
+
+mkdir -p $jail
+sudo debootstrap wheezy $jail
+
+echo 'fn main() {}' > /tmp/16229.rs
+sudo mv /tmp/16229.rs $jail/16229.rs
+
+rustc_location=$(which rustc)
+
+for dependency in $(ldd $rustc_location | grep '/' | cut -d'>' -f2 | cut -d'(' -f1); do
+  sudo mkdir -p $jail$(dirname $dependency)
+  sudo cp $dependency $jail$dependency
+done
+
+
+sudo cp -r $(dirname $(dirname $rustc_location))/lib $jail
+
+sudo mkdir -p $jail/bin
+sudo cp $rustc_location $jail/bin/rustc
+
+sudo chroot $jail /bin/rustc /16229.rs

--- a/test.sh
+++ b/test.sh
@@ -14,3 +14,8 @@ do
     exit 1
   fi
 done
+
+echo "Testing 16229"
+if bash 16229.sh > /dev/null 2>&1; then
+  exit 1
+fi


### PR DESCRIPTION
rust-lang/rust#16229

This issue happens on a chroot without proc, sys and dev mounted.
So this scripts sets up a debian chroot using debootstrap and copies the
rustc into the jail.

This cannot run on the container infrastructure of Travis, so the tests will become slower when merged.