### PR TITLE
22387

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,10 @@ if rustc --version 2>&1 | true; then
   exit 1
 fi
 
+set +o pipefail
+echo "Testing 22387"
+echo -e '\xD2' | rustc - 2>&1 | grep -q 'internal compiler error' || exit 1
+
 for f in src/*
 do
   echo "Testing $f:"


### PR DESCRIPTION
See rust-lang/rust#22387. It seems this requires reading from stdin, so
it must use the script; it greps explicitly for 'internal compiler error'
because it would never actually compile even without compiler bugs.