### PR TITLE
Make travis use containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: rust
 rust: nightly
 script: bash test.sh


### PR DESCRIPTION
This adds `sudo: false`, which causes travis to use the new
container-based infra.

http://docs.travis-ci.com/user/migrating-from-legacy/